### PR TITLE
Removed php-etl/bucket-contracts from the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "php": "^8.0",
         "psr/log": "^1.1@dev",
         "php-etl/bucket": "^0.2.0",
-        "php-etl/pipeline-contracts": "^0.2.0",
-        "php-etl/bucket-contracts": "^0.1.0"
+        "php-etl/pipeline-contracts": "^0.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2a79793a77cda316c65103387cb40df",
+    "content-hash": "0c1c2b773c3ad157934d055978a1f7f2",
     "packages": [
         {
             "name": "php-etl/bucket",


### PR DESCRIPTION
Ce package a été supprimé du composer.json car il est require dans un autre package (bucket).